### PR TITLE
Add Spock Reports and SLF4J dependencies for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,32 @@
                 <version>4.0.15</version>
                 <scope>test</scope>
             </dependency>
+            <!-- Spock Reports -->
+            <dependency>
+                <groupId>com.athaydes</groupId>
+                <artifactId>spock-reports</artifactId>
+                <version>2.5.1-groovy-4.0</version>
+                <scope>test</scope>
+                <!-- this avoids affecting your version of Groovy/Spock -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.36</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>1.7.36</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
The changes include adding Spock Reports and Simple Logging Facade for Java (SLF4J) as test scope dependencies in the pom.xml file. Spock Reports is added to generate human-readable test reports. The reports will improve how we track and understand test results across the team. SLF4J is necessary for logging during the tests. It will help in identifying and resolving issues that may arise during the testing phase.